### PR TITLE
Add otponly mode, where only the OTP password is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ This installs the following binaries:
 * `/usr/libexec/auth/login_otp`: the main login program for TOTP or HOTP.
 * `/usr/libexec/auth/login_totp`: hardlink that only accepts TOTP.
 * `/usr/libexec/auth/login_hotp`: hardlink that only accepts HOTP.
+* `/usr/libexec/auth/login_otp_only`: hardlink that only requires TOTP or HOTP without the user's system password.
+* `/usr/libexec/auth/login_totp_only`: hardlink that only requires TOTP without the user's system password.
+* `/usr/libexec/auth/login_hotp_only`: hardlink that only requires HOTP without the user's system password.
 
 Usage
 -----

--- a/login_otp.8
+++ b/login_otp.8
@@ -21,7 +21,10 @@
 .Sh NAME
 .Nm login_otp ,
 .Nm login_hotp ,
-.Nm login_totp
+.Nm login_totp ,
+.Nm login_otp_only ,
+.Nm login_hotp_only ,
+.Nm login_totp_only
 .Nd provide OATH-compatible one-time password authentication types
 .Sh SYNOPSIS
 .Nm login_otp
@@ -57,7 +60,14 @@ utility can be called as
 or
 .Nm login_totp
 to either allow HOTP or TOTP passwords,
-or to enforce HTOP or TOTP passwords accordingly.
+or to enforce HTOP or TOTP passwords accordingly,
+or as
+.Nm login_otp_only ,
+.Nm login_hotp_only ,
+or
+.Nm login_totp
+to only require the HOTP or TOTP password without being combined with
+the user's system password.
 .Pp
 The
 .Ar user
@@ -88,7 +98,7 @@ This is used by
 .Pp
 If the
 .Cm lastchance
-argument is8 specified and is equal to
+argument is specified and is equal to
 .Cm yes ,
 then if the user's password has expired, and it has not been
 expired longer than
@@ -108,6 +118,17 @@ and password
 .Bd -literal -offset indent
 login: user
 OTP + password for "user":123456test-123
+.Ed
+.Pp
+When invoked as
+.Nm login_otp_only ,
+.Nm login_hotp_only ,
+or
+.Nm login_totp_only ,
+only the OTP password is required:
+.Bd -literal -offset indent
+login: user
+OTP for "user":123456
 .Ed
 .Pp
 The user obtains a valid OTP from an OATH-compatible external authenticator,

--- a/login_otp/Makefile
+++ b/login_otp/Makefile
@@ -10,6 +10,9 @@ DPADD=		${LIBUTIL}
 BINDIR=		/usr/libexec/auth
 
 LINKS=		${BINDIR}/${PROG} ${BINDIR}/login_totp \
-		${BINDIR}/${PROG} ${BINDIR}/login_hotp
+		${BINDIR}/${PROG} ${BINDIR}/login_hotp \
+		${BINDIR}/${PROG} ${BINDIR}/login_otp_only \
+		${BINDIR}/${PROG} ${BINDIR}/login_totp_only \
+		${BINDIR}/${PROG} ${BINDIR}/login_hotp_only
 
 .include <bsd.prog.mk>


### PR DESCRIPTION
When invoked as login_otp_only, login_totp_only, or login_hotp_only,
the user's system password is not required to be appended to the
TOTP password.

This is useful with OpenSSH's AuthenticationMethods option which can
require, for example, a user's SSH key first, then require
keyboard-interactive to call login_otp_only to require an OTP from
the user.